### PR TITLE
условное отрицание

### DIFF
--- a/lection-02.tex
+++ b/lection-02.tex
@@ -215,7 +215,7 @@ $$\llparenthesis\alpha\rrparenthesis = \left\{\begin{array}{ll}\alpha, & x = \te
 \end{defrus}
 
 Аналогично записи для оценок, будем указывать оценку переменных, если это потребуется / будет неочевидно из контекста:
-$$\llparenthesis \neg X \rrparenthesis^{X:=\textnormal{Л}} = \neg\neg X\quad\quad\quad\llparenthesis \neg X \rrparenthesis^{X:=\textnormal{И}} = \neg X$$
+$$\llparenthesis \neg X \rrparenthesis^{X:=\textnormal{Л}} = \neg X\quad\quad\quad\llparenthesis \neg X \rrparenthesis^{X:=\textnormal{И}} = \neg\neg X$$
 
 Также, если $\Gamma = \gamma_1, \gamma_2, \dots, \gamma_n$, то за $\llparenthesis \Gamma \rrparenthesis$ обозначим $\llparenthesis \gamma_1 \rrparenthesis, \llparenthesis \gamma_2 \rrparenthesis, \dots \llparenthesis \gamma_n \rrparenthesis$.
 \end{frame}

--- a/lection-03.tex
+++ b/lection-03.tex
@@ -413,7 +413,7 @@ $\llbracket A \with\neg A\rrbracket = 0$, $\llbracket A\rightarrow A \rrbracket 
 \begin{thmrus}$\mathcal{L}$ --- псевдобулева алгебра.\end{thmrus}
 \begin{proof}[Схема доказательства] Надо показать, что $(\preceq)$ есть отношение порядка на $\mathcal{L}$, что
 $[\alpha\vee\beta]_\mathcal{L} = [\alpha]_\mathcal{L}+[\beta]_\mathcal{L}$, 
-$[\alpha\with\beta]_\mathcal{L}[\alpha]_\mathcal{L} = \cdot[\beta]_\mathcal{L}$, импликация есть псевдодополнение,
+$[\alpha\with\beta]_\mathcal{L} = [\alpha]_\mathcal{L}\cdot[\beta]_\mathcal{L}$, импликация есть псевдодополнение,
 $[A\with\neg A]_\mathcal{L} = 0$, $[\alpha]_\mathcal{L}\rightarrow 0 = [\neg\alpha]_\mathcal{L}$.\end{proof}
 \end{frame}
 

--- a/lection-04.tex
+++ b/lection-04.tex
@@ -84,7 +84,7 @@ $\llbracket \alpha\star\beta \rrbracket = f_\star(\llbracket \alpha \rrbracket, 
 $\llbracket \neg\alpha \rrbracket = f_\neg(\llbracket\alpha\rrbracket)$ --- табличная.
 
 Если $\vdash \alpha$ влечёт $\llbracket\alpha\rrbracket = T$ при всех оценках пропозициональных переменных $f_P$, 
-то $\mathcal{M} := \langle V, T, f_\with, f_\vee, f_\rightarrow, f_neg\rangle$ --- табличная модель.
+то $\mathcal{M} := \langle V, T, f_\with, f_\vee, f_\rightarrow, f_\neg\rangle$ --- табличная модель.
 \end{defrus}
 
 \begin{defrus}Табличная модель конечна, если $V$ конечно.\end{defrus}

--- a/lection-08.tex
+++ b/lection-08.tex
@@ -211,8 +211,8 @@ $... = N(x+y) = x+y+1$
 \item Неформально: все функции, вычисляемые конечным числом вложенных циклов \verb!for!:
 
 \begin{verbatim}
-for (int i1 = 0; i_1 < g1(x1...xn); i1++) {
-    for (int i2 = 0; i_2 < g2(x1...xn,i1); i2++) {
+for (int i1 = 0; i1 < g1(x1...xn); i1++) {
+    for (int i2 = 0; i2 < g2(x1...xn,i1); i2++) {
         ...
            for (int ik = 0; ik < gk(x1...xn,i1,i2...); ik++) {
                // выражение без циклов

--- a/lection-08.tex
+++ b/lection-08.tex
@@ -69,7 +69,7 @@ $\mathcal{H} \not\models \alpha$.
 построенная по $\llbracket \varphi_1 \rrbracket, \dots, \llbracket \varphi_n \rrbracket$, $0$ и $1$. 
 
 Очевидно, что $\mathcal{G}$ --- алгебра Гейтинга, и можно показать, 
-что $\mathcal{G} \not\models \alpha$ (псевдодоплонения не обязаны сохраниться).
+что $\mathcal{G} \not\models \alpha$ (псевдодополнения не обязаны сохраниться).
 Тогда по лемме, $|\mathcal{G}| \le 2^{2^{n+2}}$. 
 \end{proof}
 


### PR DESCRIPTION
Трофимов Никита M3239
![image](https://user-images.githubusercontent.com/89209371/232558910-17b5efbe-75cb-4514-b038-496b47ac567f.png)

В примерах ниже alpha=!X, при оценке X:=false alpha оценивается в true, поэтому условное отрицание (по опр. выше на этом слайде) (|!X|)=!X, аналогично для второго примера.

Исправленное:
![image](https://user-images.githubusercontent.com/89209371/232559254-b88b3c42-1a45-43ff-9809-a17b1a1fd04c.png)
