### PR TITLE
Add \omega * 0 in lection-10.tex by Chulkov Alexey

### DIFF
--- a/lection-10.tex
+++ b/lection-10.tex
@@ -189,7 +189,7 @@ $$a ^ b \equiv \left\{ \begin{array}{rl}
    (a ^ c) \cdot a, & b \equiv c'\\
    \sup \{ a^c \mid c \prec b \}, &\mbox{$b$ --- предельный ординал }\end{array}\right.$$
 \pause
-\begin{exm}$\omega \cdot \omega = \sup\{\omega,\omega\cdot 2, \omega\cdot 3, \dots\}$\end{exm}
+\begin{exm}$\omega \cdot \omega = \sup\{\omega \cdot 0, \omega \cdot 1,\omega\cdot 2, \omega\cdot 3, \dots\} = \sup\{0, \omega,\omega\cdot 2, \omega\cdot 3, \dots\}$\end{exm}
 \end{frame}
 
 \begin{frame}{Ординалы (порядковые числа) и порядок}


### PR DESCRIPTION
Без 0 в супремуме создается впечатление, будто бы его нет в \omega, так как дальше взяты последовательные элементы 1, 2, 3